### PR TITLE
Add blockAndSend() and approveAndSend() methods to Response class

### DIFF
--- a/src/Hooks/Response.php
+++ b/src/Hooks/Response.php
@@ -38,6 +38,19 @@ class Response
 
         return $this;
     }
+    
+    /**
+     * Block the tool call and immediately send the response
+     * Useful for replacing tool output entirely
+     * 
+     * @param string $reason The reason/content to provide instead of tool execution
+     */
+    public function blockAndSend(string $reason): never
+    {
+        $this->data['decision'] = 'block';
+        $this->data['reason'] = $reason;
+        $this->send();
+    }
 
     /**
      * Approve the tool call (PreToolUse only)
@@ -50,6 +63,20 @@ class Response
         }
 
         return $this;
+    }
+    
+    /**
+     * Approve the tool call and immediately send the response
+     * 
+     * @param string $reason Optional approval reason
+     */
+    public function approveAndSend(string $reason = ''): never
+    {
+        $this->data['decision'] = 'approve';
+        if ($reason) {
+            $this->data['reason'] = $reason;
+        }
+        $this->send();
     }
 
     /**

--- a/tests/Hooks/ExtendedResponseTest.php
+++ b/tests/Hooks/ExtendedResponseTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use BeyondCode\ClaudeHooks\Hooks\Response;
+
+it('can block and send immediately', function () {
+    $response = new class extends Response {
+        public function testBlockAndSend(): void {
+            ob_start();
+            try {
+                $this->blockAndSend('Tool execution blocked');
+            } catch (SystemExit $e) {
+                // Expected
+            }
+            $output = ob_get_clean();
+            
+            $data = json_decode($output, true);
+            expect($data)->toBeArray();
+            expect($data['decision'])->toBe('block');
+            expect($data['reason'])->toBe('Tool execution blocked');
+        }
+    };
+    
+    $response->testBlockAndSend();
+});
+
+it('can approve and send immediately', function () {
+    $response = new class extends Response {
+        public function testApproveAndSend(): void {
+            ob_start();
+            try {
+                $this->approveAndSend('Tool execution approved');
+            } catch (SystemExit $e) {
+                // Expected
+            }
+            $output = ob_get_clean();
+            
+            $data = json_decode($output, true);
+            expect($data)->toBeArray();
+            expect($data['decision'])->toBe('approve');
+            expect($data['reason'])->toBe('Tool execution approved');
+        }
+    };
+    
+    $response->testApproveAndSend();
+});
+
+it('blockAndSend terminates execution', function () {
+    $response = new Response();
+    
+    expect(function () use ($response) {
+        $response->blockAndSend('Blocked');
+    })->toThrow(SystemExit::class);
+});
+
+it('approveAndSend terminates execution', function () {
+    $response = new Response();
+    
+    expect(function () use ($response) {
+        $response->approveAndSend('Approved');
+    })->toThrow(SystemExit::class);
+});


### PR DESCRIPTION

## Problem

The current Response class requires method chaining to build responses, but the `send()` method is protected. This creates a gap when you need to immediately block or approve a tool and send the response in one operation.

Currently, to block a tool and send the response, you must:
```php
$hook->response()->block('reason'); // Returns self, but cannot call send()
// No way to send without extending the class
```

## Solution

This PR adds two methods that combine decision-making with sending:

- `blockAndSend(string $reason): never` - Blocks tool execution and sends response
- `approveAndSend(string $reason = ''): never` - Approves tool execution and sends response

## Use Case

When building middleware hooks that intercept tool calls (e.g., routing WebSearch to a different API), you need to:
1. Block the original tool execution
2. Provide replacement content
3. Send the response immediately

Without these methods, developers must create extended hook classes with custom logic.

## Implementation

```php
public function blockAndSend(string $reason): never
{
    $this->data['decision'] = 'block';
    $this->data['reason'] = $reason;
    $this->send();
}

public function approveAndSend(string $reason = ''): never
{
    $this->data['decision'] = 'approve';
    if ($reason) {
        $this->data['reason'] = $reason;
    }
    $this->send();
}
```

## Testing

Added tests in `tests/Hooks/ExtendedResponseTest.php` to verify:
- Correct JSON output structure
- Proper decision values
- Execution termination behavior

## Breaking Changes

None. These are new methods that don't affect existing functionality.

## Alternative Considered

Making `send()` public was considered but rejected to maintain encapsulation and prevent misuse of the response flow.