### PR TITLE
Add Support for UserPromptSubmit Hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The SDK automatically creates the appropriate hook type based on the input:
 
 ```php
 use BeyondCode\ClaudeHooks\ClaudeHook;
-use BeyondCode\ClaudeHooks\Hooks\{PreToolUse, PostToolUse, Notification, Stop, SubagentStop};
+use BeyondCode\ClaudeHooks\Hooks\{PreToolUse, PostToolUse, Notification, UserPromptSubmit, Stop, SubagentStop};
 
 $hook = ClaudeHook::create();
 
@@ -86,6 +86,10 @@ if ($hook instanceof PostToolUse) {
 if ($hook instanceof Notification) {
     $message = $hook->message();
     $title = $hook->title();
+}
+
+if ($hook instanceof UserPromptSubmit) {
+    $prompt = $hook->prompt();
 }
 
 if ($hook instanceof Stop || $hook instanceof SubagentStop) {
@@ -204,6 +208,32 @@ $notificationData = [
     
 // Send notification to Slack, Discord, etc.
 
+$hook->success();
+```
+
+#### User Prompt Submit Hook
+
+Validate and add context to user prompts:
+
+```php
+<?php
+
+require 'vendor/autoload.php';
+
+use BeyondCode\ClaudeHooks\ClaudeHook;
+use BeyondCode\ClaudeHooks\Hooks\UserPromptSubmit;
+
+$hook = ClaudeHook::create();
+
+// Check for sensitive patterns
+if (str_contains($hook->prompt(), 'password') || str_contains($hook->prompt(), 'secret')) {
+    // Block the prompt
+    $hook->response()->block('Security policy violation: Please rephrase without sensitive information.');
+}
+
+// Add context via stdout
+echo "Current time: " . date('Y-m-d H:i:s') . "\n";
+echo "Project status: Active development\n";
 $hook->success();
 ```
 

--- a/README.md
+++ b/README.md
@@ -225,16 +225,31 @@ use BeyondCode\ClaudeHooks\Hooks\UserPromptSubmit;
 
 $hook = ClaudeHook::create();
 
-// Check for sensitive patterns
-if (str_contains($hook->prompt(), 'password') || str_contains($hook->prompt(), 'secret')) {
-    // Block the prompt
-    $hook->response()->block('Security policy violation: Please rephrase without sensitive information.');
+// Ask Claude Code - what is my secret-code?
+// It should respond with ABC123 thanks to our injected prompt
+
+if ($hook instanceof UserPromptSubmit) {
+    $prompt = $hook->prompt();
+    $lowerPrompt = strtolower($prompt);
+    
+    // Add context via your script and output the "fancy" way
+    if (str_contains($lowerPrompt, 'secret-code')) {
+        $contextReminder = "\n\n🔍 Your secret code is 'ABC123'";
+        $modifiedPrompt = $prompt . $contextReminder;
+        
+        $hook->response()->merge(['prompt' => $modifiedPrompt])->continue();
+        return;
+    }
+
+    // Add context via your script and output directly to stdout
+    if (str_contains($lowerPrompt, 'laravel')) {
+        echo PHP_EOL . PHP_EOL . 'Remember, this is a Laravel project, so use laravel-boost mcp server and related tools.';
+        return;
+    }
 }
 
-// Add context via stdout
-echo "Current time: " . date('Y-m-d H:i:s') . "\n";
-echo "Project status: Active development\n";
-$hook->success();
+// For all other hook types, allow them to proceed
+$hook->response()->continue();
 ```
 
 

--- a/src/ClaudeHook.php
+++ b/src/ClaudeHook.php
@@ -8,6 +8,7 @@ use BeyondCode\ClaudeHooks\Hooks\PostToolUse;
 use BeyondCode\ClaudeHooks\Hooks\PreToolUse;
 use BeyondCode\ClaudeHooks\Hooks\Stop;
 use BeyondCode\ClaudeHooks\Hooks\SubagentStop;
+use BeyondCode\ClaudeHooks\Hooks\UserPromptSubmit;
 
 class ClaudeHook
 {
@@ -15,6 +16,7 @@ class ClaudeHook
         'PreToolUse' => PreToolUse::class,
         'PostToolUse' => PostToolUse::class,
         'Notification' => Notification::class,
+        'UserPromptSubmit' => UserPromptSubmit::class,
         'Stop' => Stop::class,
         'SubagentStop' => SubagentStop::class,
     ];

--- a/src/Hooks/UserPromptSubmit.php
+++ b/src/Hooks/UserPromptSubmit.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace BeyondCode\ClaudeHooks\Hooks;
+
+class UserPromptSubmit extends Hook
+{
+    protected string $prompt;
+
+    public function __construct(array $data)
+    {
+        parent::__construct($data);
+        $this->prompt = $data['prompt'] ?? '';
+    }
+
+    public function eventName(): string
+    {
+        return 'UserPromptSubmit';
+    }
+
+    public function prompt(): string
+    {
+        return $this->prompt;
+    }
+}

--- a/tests/ClaudeHookTest.php
+++ b/tests/ClaudeHookTest.php
@@ -6,6 +6,7 @@ use BeyondCode\ClaudeHooks\Hooks\PostToolUse;
 use BeyondCode\ClaudeHooks\Hooks\PreToolUse;
 use BeyondCode\ClaudeHooks\Hooks\Stop;
 use BeyondCode\ClaudeHooks\Hooks\SubagentStop;
+use BeyondCode\ClaudeHooks\Hooks\UserPromptSubmit;
 
 it('creates PreToolUse hook from stdin', function () {
     $stdin = json_encode([
@@ -92,6 +93,24 @@ it('creates SubagentStop hook from stdin', function () {
     expect($hook)->toBeInstanceOf(SubagentStop::class);
     expect($hook->eventName())->toBe('SubagentStop');
     expect($hook->stopHookActive())->toBe(false);
+});
+
+it('creates UserPromptSubmit hook from stdin', function () {
+    $stdin = json_encode([
+        'session_id' => 'test-session',
+        'transcript_path' => '/path/to/transcript.jsonl',
+        'cwd' => '/path/to/project',
+        'hook_event_name' => 'UserPromptSubmit',
+        'prompt' => 'Write a function to calculate factorial',
+    ]);
+
+    $hook = ClaudeHook::fromStdin($stdin);
+
+    expect($hook)->toBeInstanceOf(UserPromptSubmit::class);
+    expect($hook->eventName())->toBe('UserPromptSubmit');
+    expect($hook->prompt())->toBe('Write a function to calculate factorial');
+    expect($hook->sessionId())->toBe('test-session');
+    expect($hook->transcriptPath())->toBe('/path/to/transcript.jsonl');
 });
 
 it('throws exception for invalid JSON', function () {

--- a/tests/Hooks/UserPromptSubmitTest.php
+++ b/tests/Hooks/UserPromptSubmitTest.php
@@ -1,0 +1,22 @@
+<?php
+
+use BeyondCode\ClaudeHooks\Hooks\UserPromptSubmit;
+
+beforeEach(function () {
+    $this->data = [
+        'session_id' => 'test-session',
+        'transcript_path' => '/path/to/transcript.jsonl',
+        'prompt' => 'Write a function to calculate factorial',
+    ];
+});
+
+it('accesses prompt', function () {
+    $hook = new UserPromptSubmit($this->data);
+    expect($hook->prompt())->toBe('Write a function to calculate factorial');
+});
+
+it('handles missing prompt gracefully', function () {
+    unset($this->data['prompt']);
+    $hook = new UserPromptSubmit($this->data);
+    expect($hook->prompt())->toBe('');
+});


### PR DESCRIPTION
# Add UserPromptSubmit Hook Support

This PR introduces the UserPromptSubmit hook, enabling developers to intercept, validate, and augment user prompts before they're processed by Claude Code. This allows for dynamic context injection plus additional ways to add prompt validation and workflow customization.

## 🚀 What's New

  - New Hook Type: UserPromptSubmit hook that triggers when users submit prompts to Claude Code
  - Prompt Access: Direct access to user prompts via the prompt() method
  - Context Injection: Two ways to add context to prompts:
    - Simple: Output to stdout and call success()
    - Advanced: Use response()->merge(['prompt' => $modifiedPrompt]) for more structured modifications

## 🏗️ Implementation Details

  Core Components Added:
  - src/Hooks/UserPromptSubmit.php - New hook implementation with prompt access
  - Updated src/ClaudeHook.php - Registered new hook type in event map
  - Test coverage updated in tests/Hooks/UserPromptSubmitTest.php and tests/ClaudeHookTest.php

## 💡 Usage Examples

  Basic Prompt Validation:
```php
  if ($hook instanceof UserPromptSubmit) {
      $prompt = $hook->prompt();

      if (str_contains(strtolower($prompt), 'delete database')) {
          $hook->response()->block('Dangerous operation blocked');
          return;
      }
  }
```

  Dynamic Context Injection:
```php
  if ($hook instanceof UserPromptSubmit) {
      $prompt = $hook->prompt();

      // Add project-specific context with basic output
      if (str_contains(strtolower($prompt), 'laravel')) {
          echo PHP_EOL . 'Remember: Use Larvel Boost MCP Server + Tools to check for errors before submission';
          $hook->success();
          return;
      }

      // Alternative output method via response()
      if (str_contains(strtolower($prompt), 'secret-code')) {
          $contextReminder = "\n\n🔍 Your secret code is 'ABC123'";
          $hook->response()->merge(['prompt' => $prompt . $contextReminder])->continue();
          return;
      }
  }
```

  Workflow Customization:
```php
  if ($hook instanceof UserPromptSubmit) {
      $prompt = $hook->prompt();

      // Inject environment-specific reminders
      if (str_contains($prompt, 'deploy') || str_contains($prompt, 'production')) {
          echo "\n⚠️  PRODUCTION REMINDER: Always run the full Dusk test suite before deploying!";
          $hook->success();
          return;
      }
  }
```
  🔄 Breaking Changes

  None. This is a purely additive change that maintains full backward compatibility with existing hook implementations.


